### PR TITLE
Scoping transcluded content to parent scope

### DIFF
--- a/example/load-on-demand/index.html
+++ b/example/load-on-demand/index.html
@@ -85,8 +85,8 @@
             <div>
                 Hello !
                 <ul>
-                <li ng-repeat="thing in $parent.vm.things">
-                    <a ng-click="$parent.$parent.vm.doSomething(thing.name)">{{thing.code}} - {{thing.name}}</a>
+                <li ng-repeat="thing in vm.things">
+                    <a ng-click="vm.doSomething(thing.name)">{{thing.code}} - {{thing.name}}</a>
                 </li>
               </ul>
             </div>

--- a/src/drop-ng.js
+++ b/src/drop-ng.js
@@ -31,7 +31,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
         },
         link: {
           pre: function(scope, element, attrs, ctrl, transclude){
-            transclude(scope, function(clone, scope) {
+            transclude(scope.$parent, function(clone, scope) {
               element.append(clone);
             });
           },
@@ -44,7 +44,6 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
               if (drop) {
                 drop.destroy();
               }
-
               if (typeof scope.classes == 'undefined') scope.classes = 'drop-theme-arrows-bounce';
               if (typeof scope.constrainToScrollParent == 'undefined') scope.constrainToScrollParent = true;
               if (typeof scope.constrainToWindow == 'undefined') scope.constrainToWindow = true;


### PR DESCRIPTION
This avoids the need for using $parent in the transcluded content to bind
to values for the parent scope / controller.