### PR TITLE
Added drop-focus directive

### DIFF
--- a/example/set-focus-on-open/index.html
+++ b/example/set-focus-on-open/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html>
+<head>
+  <!-- angular -->
+  <script src="../../bower_components/angular/angular.min.js"></script>
+
+  <!-- dropjs including tether -->
+  <script src="../../bower_components/drop/drop.min.js"></script>
+  <link href="../../bower_components/drop/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
+  <link href="../../bower_components/drop/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
+
+  <!-- drop-ng -->
+  <script src="../../src/drop-ng.js"></script>
+
+  <!-- my application javascript-->
+  <script>
+    'use strict';
+
+    var myapp = angular.module('myapp', ['drop-ng']);
+
+    myapp.controller('mycontroller', function ($scope) {
+      $scope.classes = 'drop-theme-arrows-bounce-dark';
+      $scope.constrainToScrollParent = 'true';
+      $scope.constrainToWindow = 'true';
+      $scope.openOn = 'click';
+      $scope.position = 'bottom center';
+      $scope.someValue = 'value from controller';
+    });
+  </script>
+
+  <!-- my application styles -->
+  <style>
+    body {
+      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      color: #333
+    }
+    button {
+      margin-left:200px
+    }
+    .ng-hide {
+      display: none !important;
+    }
+    .leave-space-for-drop {
+      margin-top: 100px
+    }
+  </style>
+</head>
+<body ng-app="myapp">
+  <h2>drop-ng example</h2>
+
+  <div ng-controller="mycontroller">
+    <div>
+      <p>
+        <span>
+          drop-ng provides an Angular wrapper around Drop.js. <br/><br/>
+          Drop.js is a Javascript and CSS library for creating dropdowns and other popups attached to elements on the page.
+        </span>
+      </p>
+      <p>
+        <span>You can edit the follwing text in the dropdown: {{someValue}}</span>
+      </p>
+      <button>
+        Click me
+
+        <drop classes='classes'
+              constrain-to-scroll-parent='constrainToScrollParent'
+              constrain-to-window='constrainToWindow'
+              open-on='openOn'
+              position='position'>
+
+            <div>
+                You can start typing immediately
+                <br/>
+                <input type="text" drop-focus ng-model="someValue"/>
+            </div>
+
+        </drop>
+      </button>
+
+      <p class="leave-space-for-drop">
+        <span>
+          Use the 'position' attribute to define the position of the popover:
+        </span>
+      </p>
+      <p>
+        <input type="radio" name="position" ng-model="position" value="top left"> Top left <br/>
+        <input type="radio" name="position" ng-model="position" value="top center"> Top center <br/>
+        <input type="radio" name="position" ng-model="position" value="top right"> Top right <br/>
+        <input type="radio" name="position" ng-model="position" value="bottom left">  Bottom left <br/>
+        <input type="radio" name="position" ng-model="position" value="bottom center"> Bottom center <br/>
+        <input type="radio" name="position" ng-model="position" value="bottom right"> Bottom right <br/>
+        <input type="radio" name="position" ng-model="position" value="left middle"> Left middle <br/>
+        <input type="radio" name="position" ng-model="position" value="right middle"> Right middle <br/>
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/drop-ng.js
+++ b/src/drop-ng.js
@@ -33,11 +33,15 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
         controller: function($scope){
             var _this = this;
             this.drop = null;
+            this.focusElement = null;
+            this.setFocusElement = function(element){
+                this.focusElement = element;
+            };
             this.close = function(){
                 if (_this.drop){
                     _this.drop.close();
                 }
-            }        
+            };       
         },
         link: {
           pre: function(scope, element, attrs, ctrl, transclude){
@@ -51,7 +55,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
             var dropContent = compiled(scope)[0];
             var initDrop = function() {
               if (ctrl.drop) {
-                ctrl.drop.destroy();
+                ctrl.drop.off('open', openHandler);
+                ctrl.drop.destroy();                
               }
               if (typeof scope.classes == 'undefined') scope.classes = 'drop-theme-arrows-bounce';
               if (typeof scope.constrainToScrollParent == 'undefined') scope.constrainToScrollParent = true;
@@ -68,12 +73,17 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                 position: scope.position,
                 openOn: scope.openOn
               });
+              
+              ctrl.drop.on('open', openHandler);
+            }
+            
+            var openHandler = function(){
+                if (ctrl.focusElement){
+                    ctrl.focusElement[0].focus();
+                }
             }
 
             initDrop();
-
-            // clean up element
-            //element[0].innerHTML = '';
 
             scope.$watch('classes', function (newValue, oldValue) {
               if (newValue !== oldValue)
@@ -101,7 +111,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
             });
 
             scope.$on('$destroy', function () {
-              if (ctrl.drop) ctrl.drop.destroy();
+              if (ctrl.drop){
+                  ctrl.drop.off('open', openHandler);
+                  ctrl.drop.destroy();
+              }
               if (initDrop) initDrop.destroy();
               setTimeout(function () {
                 element.remove();
@@ -119,6 +132,15 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                 element.on('click', function(){                
                     dropCtrl.close();
                 });
+            }
+        };
+    })
+    .directive('dropFocus', function(){
+        return {
+            require: '^drop',
+            restrict: 'A',
+            link: function(scope, element, attrs, dropCtrl){
+                dropCtrl.setFocusElement(element);
             }
         };
     });


### PR DESCRIPTION
Using the drop-focus directive, you can specify an input element to get
focus when the dropdown is opened.

For example:

````
<button>
    Click me
    <drop>
       <div>
            You can start typing immediately
            <br/>
            <input type="text" drop-focus ng-model="someValue"/>
        </div>
    </drop>
</button>
````

