### PR TITLE
Trigger close event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "drop-ng",
-  "version": "0.0.3",
+  "version": "0.0.31",
   "description": "An AngularJS wrapper module for Drop.js",
   "authors": [
     "stevenh77 <stevenhollidge@hotmail.com>"

--- a/example/close-event/index.html
+++ b/example/close-event/index.html
@@ -19,15 +19,12 @@
     var myapp = angular.module('myapp', ['drop-ng']);
 
     myapp.controller('mycontroller', function ($scope, $rootScope) {
-      $scope.classes = 'drop-theme-arrows-bounce-dark';
-      $scope.constrainToScrollParent = 'true';
-      $scope.constrainToWindow = 'true';
-      $scope.openOn = 'click';
-      $scope.position = 'bottom center';
-      $scope.someValue = 'value from controller';
-
+      $scope.eventsList = [];
+      
       var dropClosedEventListener = $rootScope.$on('dropClosedEvent', function (event, data) {
-        console.log("dropClosedEvent fired");
+        var eventTime = new Date().toISOString();
+        $scope.eventsList.push(eventTime + " - dropClosedEvent fired");
+        $scope.$apply();
   	  });
 
   	  $scope.$on('$destroy', dropClosedEventListener);
@@ -65,45 +62,30 @@
           Drop.js is a Javascript and CSS library for creating dropdowns and other popups attached to elements on the page.
         </span>
       </p>
-      <p>
-        <span>The following text will appear within the drop:</span>
-        <input type="text" ng-model="someValue" />
-      </p>
       <button>
         Click me
 
-        <drop classes='classes'
-              constrain-to-scroll-parent='constrainToScrollParent'
-              constrain-to-window='constrainToWindow'
-              open-on='openOn'
-              position='position'>
+        <drop  position="'bottom center'">
 
           <div>
-            Hello {{ someValue }}
-            <br />
-            <p id="closeElement" drop-close>
-              <i>Click here to close</i>
-            </p>
+            Just another drop. <br/>
+            Close event is logged below          
           </div>
 
         </drop>
       </button>
 
       <p class="leave-space-for-drop">
-        <span>
-          Use the 'position' attribute to define the position of the popover:
-        </span>
+        Events:  
       </p>
-      <p>
-        <input type="radio" name="position" ng-model="position" value="top left"> Top left <br />
-        <input type="radio" name="position" ng-model="position" value="top center"> Top center <br />
-        <input type="radio" name="position" ng-model="position" value="top right"> Top right <br />
-        <input type="radio" name="position" ng-model="position" value="bottom left">  Bottom left <br />
-        <input type="radio" name="position" ng-model="position" value="bottom center"> Bottom center <br />
-        <input type="radio" name="position" ng-model="position" value="bottom right"> Bottom right <br />
-        <input type="radio" name="position" ng-model="position" value="left middle"> Left middle <br />
-        <input type="radio" name="position" ng-model="position" value="right middle"> Right middle <br />
-      </p>
+      
+      <div id="eventslog">
+        <span ng-repeat="e in eventsList track by $index">{{e}}<br/></span>
+      </div>
+<!--      <textarea ng-model="eventsList" ng-list="&#10;"></textarea>-->
+<!--      <ul>
+        <li ng-repeat="e in eventsList">{{e}}</li>
+      </ul>       -->
     </div>
   </div>
 </body>

--- a/example/trigger-close/index.html
+++ b/example/trigger-close/index.html
@@ -19,15 +19,17 @@
     var myapp = angular.module('myapp', ['drop-ng']);
 
     myapp.controller('mycontroller', function ($scope, $rootScope) {
-      $scope.eventsList = [];
+      $scope.isChecked = false;
+      $scope.highlightCheckBox = false;
+      $scope.applyChanges = function(){
+        console.log("in it");
+        if ($scope.isChecked) {
+          $scope.$broadcast("closeDrop");
+        } else {
+          $scope.highlightCheckBox = true;
+        }
+      };
       
-      var dropClosedEventListener = $rootScope.$on('dropClosedEvent', function (event, data) {
-        var eventTime = new Date().toISOString();
-        $scope.eventsList.push(eventTime + " - dropClosedEvent fired");
-        $scope.$apply();
-  	  });
-
-  	  $scope.$on('$destroy', dropClosedEventListener);
     });
   </script>
 
@@ -38,7 +40,7 @@
       color: #333;
     }
 
-    button {
+    button.launcher {
       margin-left: 200px;
     }
 
@@ -48,6 +50,11 @@
 
     .leave-space-for-drop {
       margin-top: 100px;
+    }
+    
+    .highlight{
+      color: darkred;
+      font-weight: 700;
     }
   </style>
 </head>
@@ -62,14 +69,17 @@
           Drop.js is a Javascript and CSS library for creating dropdowns and other popups attached to elements on the page.
         </span>
       </p>
-      <button>
+      <button class="launcher">
         Click me
 
         <drop  position="'bottom center'">
 
           <div>
-            Just another drop. <br/>
-            Close event is logged below          
+            Check the box and click Apply Changes to close? <br/>
+            <input id="confirmCheckBox" type="checkbox" ng-model="isChecked">I Agree <span class="highlight" ng-if="highlightCheckBox">*</span></input>
+              <br/>
+            <input id="applyChangesButton" type="submit" ng-click="applyChanges()" value="Apply Changes"></button>
+            
           </div>
 
         </drop>

--- a/src/drop-ng.js
+++ b/src/drop-ng.js
@@ -134,6 +134,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
               if (newValue !== oldValue)
                 initDrop();
             });
+            
+            scope.$on('closeDrop', function(){
+                ctrl.close();
+            });
 
             scope.$on('$destroy', function () {
               if (ctrl.drop){

--- a/tests/e2e/close-action-example.spec.js
+++ b/tests/e2e/close-action-example.spec.js
@@ -23,6 +23,9 @@ describe('[e2e] drop-ng: close action example', function () {
 
        // check drop does exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(true);
+       
+       //Annoying but this fails if we don't put a sleep here first. Protractor doesn't seem to automatically wait for the drop animation to complete.
+       browser.sleep(300);       
 
        element(by.id('closeElement')).click();
        

--- a/tests/e2e/close-event-example.spec.js
+++ b/tests/e2e/close-event-example.spec.js
@@ -24,11 +24,13 @@ describe('[e2e] drop-ng: close event example', function () {
        // check drop does exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(true);
 
-       element(by.id('closeElement')).click();
+       //now close it
+       element(by.css('.drop-target')).click();
        
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
        
+       expect(element(by.id("eventslog")).getText()).toContain("dropClosedEvent fired");
        browser.manage().logs().get('browser').then(function(browserLog) {
          // this test passes when run manually in the browser.  fix protractor code at later date
          //expect(browserLog.message).toBe('dropClosedEvent fired');

--- a/tests/e2e/trigger-close-example.spec.js
+++ b/tests/e2e/trigger-close-example.spec.js
@@ -1,0 +1,45 @@
+/**
+ * Setting up protractor and selenium
+ *  Install JDK:  http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
+ * 	npm install -g protractor
+ * 	webdriver-manager update
+ *
+ * Starting webdriver
+ * 	webdriver-manager start
+ *
+ * Starting the tests
+ *  protractor protractor.config.js
+ */
+
+describe('[e2e] drop-ng: trigger close example', function () {
+     it('should appear when clicked and close when checkbox is checked and apply changes is clicked ', function() {
+       browser.get('http://localhost:8080/example/trigger-close');
+
+       // check drop doesn't exist
+       expect(element(by.css('.drop-open')).isPresent()).toBe(false);
+
+       // click the parent button
+       element(by.css('.drop-target')).click();
+
+       // check drop does exist
+       expect(element(by.css('.drop-open')).isPresent()).toBe(true);
+       
+       //sigh...waiting required for animation
+       browser.sleep(300);
+
+       //now try closing it by clicking the apply changes button
+       element(by.id('applyChangesButton')).click();
+       
+       // it should stay open
+       expect(element(by.css('.drop-open')).isPresent()).toBe(true);
+       
+       //Now check the confirmation box
+       element(by.id("confirmCheckBox")).click();
+       
+       //close it again
+       element(by.id('applyChangesButton')).click();
+       
+       // check that it closed
+       expect(element(by.css('.drop-open')).isPresent()).toBe(false);
+     });
+ });


### PR DESCRIPTION
The Drop directive now listens for a closeDrop event. 

This allows for a scenario where a button click inside the drop can call a function in a controller. That function might do some validation and decide whether or not to trigger the drop to close or keep it open. 

Includes e2e tests and also fixed some other tests.