### PR TITLE
Updated tether drop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
     "angular": "~1.3.11",
     "angular-mocks": "~1.3.11",
     "jquery": "~2.1.3",
-    "tether-drop": "~1.0.7"
+    "tether-drop": "~1.4.2"
   }
 }

--- a/example/before-close/index.html
+++ b/example/before-close/index.html
@@ -20,12 +20,18 @@
     var myapp = angular.module('myapp', ['drop-ng']);
 
     myapp.controller('mycontroller', function ($scope) {
+      $scope.beforeCloseCount = 0;
       $scope.classes = 'drop-theme-arrows-bounce-dark';
       $scope.constrainToScrollParent = 'true';
       $scope.constrainToWindow = 'true';
       $scope.openOn = 'click';
       $scope.position = 'bottom center';
       $scope.someValue = 'value from controller';
+      $scope.beforeClose = function() {
+        $scope.beforeCloseCount++;
+        $scope.$apply();
+        return true;
+      }
     });
   </script>
 
@@ -64,6 +70,11 @@
         <span>The following text will appear within the drop:</span>
         <input type="text" ng-model="someValue" />
       </p>
+
+      <p>
+        Before close calls: <span id="nbBeforeCloseCalls">{{ beforeCloseCount }}</span>
+      </p>
+
       <button>
         Click me
 
@@ -71,7 +82,8 @@
               constrain-to-scroll-parent='constrainToScrollParent'
               constrain-to-window='constrainToWindow'
               open-on='openOn'
-              position='position'>
+              position='position'
+              before-close='beforeClose()'>
 
           <div>
             Hello {{ someValue }}

--- a/example/callback-on-open/index.html
+++ b/example/callback-on-open/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />

--- a/example/close-event/index.html
+++ b/example/close-event/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
@@ -21,7 +21,7 @@
 
     myapp.controller('mycontroller', function ($scope, $rootScope) {
       $scope.eventsList = [];
-      
+
       var dropClosedEventListener = $rootScope.$on('dropClosedEvent', function (event, data) {
         var eventTime = new Date().toISOString();
         $scope.eventsList.push(eventTime + " - dropClosedEvent fired");
@@ -70,16 +70,16 @@
 
           <div>
             Just another drop. <br/>
-            Close event is logged below          
+            Close event is logged below
           </div>
 
         </drop>
       </button>
 
       <p class="leave-space-for-drop">
-        Events:  
+        Events:
       </p>
-      
+
       <div id="eventslog">
         <span ng-repeat="e in eventsList track by $index">{{e}}<br/></span>
       </div>

--- a/example/defaults/index.html
+++ b/example/defaults/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />

--- a/example/load-on-demand/index.html
+++ b/example/load-on-demand/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
 

--- a/example/ng-repeat/index.html
+++ b/example/ng-repeat/index.html
@@ -5,10 +5,10 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
-  
+
   <!-- drop-ng -->
   <script src="../../src/drop-ng.js"></script>
 

--- a/example/rightclick/index.html
+++ b/example/rightclick/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />

--- a/example/rightclick/rightclick-close.html
+++ b/example/rightclick/rightclick-close.html
@@ -5,11 +5,11 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
-  
+
   <!-- drop-ng -->
   <script src="../../src/drop-ng.js"></script>
 

--- a/example/set-focus-on-open/index.html
+++ b/example/set-focus-on-open/index.html
@@ -5,11 +5,11 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
-  
+
   <!-- drop-ng -->
   <script src="../../src/drop-ng.js"></script>
 

--- a/example/simple/index.html
+++ b/example/simple/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />

--- a/example/style-slide-down/index.html
+++ b/example/style-slide-down/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="./drop-theme-slide-down.css" rel="stylesheet" />
 

--- a/example/tether-options/index.html
+++ b/example/tether-options/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />

--- a/example/trigger-close/index.html
+++ b/example/trigger-close/index.html
@@ -5,7 +5,7 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
@@ -30,7 +30,7 @@
           $scope.highlightCheckBox = true;
         }
       };
-      
+
     });
   </script>
 
@@ -52,7 +52,7 @@
     .leave-space-for-drop {
       margin-top: 100px;
     }
-    
+
     .highlight{
       color: darkred;
       font-weight: 700;
@@ -80,16 +80,16 @@
             <input id="confirmCheckBox" type="checkbox" ng-model="isChecked">I Agree <span class="highlight" ng-if="highlightCheckBox">*</span></input>
               <br/>
             <input id="applyChangesButton" type="submit" ng-click="applyChanges()" value="Apply Changes"></button>
-            
+
           </div>
 
         </drop>
       </button>
 
       <p class="leave-space-for-drop">
-        Events:  
+        Events:
       </p>
-      
+
       <div id="eventslog">
         <span ng-repeat="e in eventsList track by $index">{{e}}<br/></span>
       </div>

--- a/example/wijmo-grid/index.html
+++ b/example/wijmo-grid/index.html
@@ -5,11 +5,11 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
-  
+
   <!-- drop-ng -->
   <script src="../../src/drop-ng.js"></script>
 
@@ -18,7 +18,7 @@
   <script src="wijmo.grid.min.js"></script>
   <script src="wijmo.input.min.js"></script>
   <script src="wijmo.angular.min.js"></script>
-  
+
   <link href="wijmo.min.css" rel="stylesheet" />
 
   <!-- my application javascript-->
@@ -80,7 +80,7 @@
         <wj-flex-grid-column header="Docs"
                             width="70"
                             is-read-only="true">
-			<button>Click Me 
+			<button>Click Me
 				<drop classes="classes" constrain-to-scroll-parent="constrainToScrollParent" constrain-to-window="constrainToWindow" open-on="openOn" position="position">
 					<div id="displayTextWithinDrop">
 					Hello {{ someValue }}

--- a/example/wijmo-grid/positioning-bug.html
+++ b/example/wijmo-grid/positioning-bug.html
@@ -5,11 +5,11 @@
   <script src="../../bower_components/angular/angular.min.js"></script>
 
   <!-- dropjs including tether -->
-  <script src="../../bower_components/tether/tether.min.js"></script>
+  <script src="../../bower_components/tether/dist/js/tether.min.js"></script>
   <script src="../../bower_components/tether-drop/dist/js/drop.min.js"></script>
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce.css" rel="stylesheet" />
   <link href="../../bower_components/tether-drop/dist/css/drop-theme-arrows-bounce-dark.css" rel="stylesheet" />
-  
+
   <!-- drop-ng -->
   <script src="../../src/drop-ng.js"></script>
 
@@ -18,7 +18,7 @@
   <script src="wijmo.grid.min.js"></script>
   <script src="wijmo.input.min.js"></script>
   <script src="wijmo.angular.min.js"></script>
-  
+
   <link href="wijmo.min.css" rel="stylesheet" />
 
   <!-- my application javascript-->
@@ -34,7 +34,7 @@
       $scope.openOn = 'click';
       $scope.position = 'bottom center';
       $scope.someValue = 'value from controller';
-      
+
       var countries = 'US,Germany,UK,Japan,Italy,Greece'.split(','),
       data = [];
       for (var i = 0; i < countries.length; i++) {
@@ -72,7 +72,7 @@
 
   	<div class="grid-container">
 
-  		<wj-flex-grid id="grid" items-source="rowData" control="flex" selection-mode="None"> 
+  		<wj-flex-grid id="grid" items-source="rowData" control="flex" selection-mode="None">
   			<wj-flex-grid-column header="Id"
 								   binding="id"
 								   width="50"
@@ -90,7 +90,7 @@
   					Click Me
   					<drop classes="classes" constrain-to-scroll-parent="constrainToScrollParent" constrain-to-window="constrainToWindow" open-on="openOn" position="position">
   						<div id="displayTextWithinDrop">
-  							Hello {{ someValue }}                       
+  							Hello {{ someValue }}
   						</div>
   					</drop>
   				</button>

--- a/src/drop-ng.js
+++ b/src/drop-ng.js
@@ -36,14 +36,15 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
           openOn: '=?',
           dropInstance: '=?',
           callbackOnOpen: '&',
-          tetherOptions: '=?'
+          tetherOptions: '=?',
+          beforeClose: '&'
         },
         controller: function(){
           var _this = this;
           this.drop = null;
           this.focusElement = null;
           this.focusDelay;
-          
+
           this.setFocusElement = function(element, delay){
             this.focusElement = element;
             this.focusDelay = delay;
@@ -78,7 +79,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
               // Apply defaults for both null and undefined.  Note: false is a valid value for tetherOptions.
               if (typeof scope.tetherOptions === 'undefined' || scope.tetherOptions === null) scope.tetherOptions = {};
 
-              ctrl.drop = new Drop({
+              var options = {
                 target: target,
                 content: dropContent,
                 classes: scope.classes,
@@ -87,7 +88,11 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                 position: scope.position,
                 openOn: scope.openOn,
                 tetherOptions: scope.tetherOptions
-              });
+              };
+
+              if (typeof scope.beforeClose == 'function') options.beforeClose = scope.beforeClose;
+
+              ctrl.drop = new Drop(options);
 
               scope.dropInstance = ctrl.drop; // expose drop instance
 

--- a/tests/e2e/before-close-example.spec.js
+++ b/tests/e2e/before-close-example.spec.js
@@ -11,9 +11,9 @@
  *  protractor protractor.config.js
  */
 
-describe('[e2e] drop-ng: trigger close example', function () {
-     it('should appear when clicked and close when checkbox is checked and apply changes is clicked ', function() {
-       browser.get('/example/trigger-close');
+describe('[e2e] drop-ng: before close example', function () {
+     it('should show the number of before close calls', function() {
+       browser.get('/example/before-close');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
@@ -24,22 +24,15 @@ describe('[e2e] drop-ng: trigger close example', function () {
        // check drop does exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(true);
 
-       //sigh...waiting required for animation
+       //Annoying but this fails if we don't put a sleep here first. Protractor doesn't seem to automatically wait for the drop animation to complete.
        browser.sleep(300);
 
-       //now try closing it by clicking the apply changes button
-       element(by.id('applyChangesButton')).click();
+       element(by.id('closeElement')).click();
 
-       // it should stay open
-       expect(element(by.css('.drop-open')).isPresent()).toBe(true);
-
-       //Now check the confirmation box
-       element(by.id("confirmCheckBox")).click();
-
-       //close it again
-       element(by.id('applyChangesButton')).click();
-
-       // check that it closed
+       // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
+
+       // check the number of before close to be one
+       expect(element(by.id('nbBeforeCloseCalls')).getText()).toEqual("1");
      });
  });

--- a/tests/e2e/callback-on-open-example.spec.js
+++ b/tests/e2e/callback-on-open-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: callback on open example', function () {
      it('should appear when parent button is clicked and console.log should have text: callback executed successfully', function() {
-       browser.get('http://localhost:8080/example/callback-on-open');
+       browser.get('/example/callback-on-open');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/close-action-example.spec.js
+++ b/tests/e2e/close-action-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: close action example', function () {
      it('should appear when parent button is clicked and close when parent button clicked again', function() {
-       browser.get('http://localhost:8080/example/close-action');
+       browser.get('/example/close-action');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
@@ -23,12 +23,12 @@ describe('[e2e] drop-ng: close action example', function () {
 
        // check drop does exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(true);
-       
+
        //Annoying but this fails if we don't put a sleep here first. Protractor doesn't seem to automatically wait for the drop animation to complete.
-       browser.sleep(300);       
+       browser.sleep(300);
 
        element(by.id('closeElement')).click();
-       
+
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
      });

--- a/tests/e2e/close-event-example.spec.js
+++ b/tests/e2e/close-event-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: close event example', function () {
      it('should appear when parent button is clicked and close when parent button clicked again, check log message was written ', function() {
-       browser.get('http://localhost:8080/example/close-event');
+       browser.get('/example/close-event');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
@@ -28,10 +28,10 @@ describe('[e2e] drop-ng: close event example', function () {
        // *** NOTE ***** As protractor struggles to click the button when the drop is open,
        // the workaround is press enter as the button currently has focus
        element.all(by.css('.drop-target')).first().sendKeys(protractor.Key.ENTER);
-       
+
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
-       
+
        expect(element(by.id("eventslog")).getText()).toContain("dropClosedEvent fired");
      });
  });

--- a/tests/e2e/defaults-example.spec.js
+++ b/tests/e2e/defaults-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: defaults example', function () {
      it('should appear when parent button is clicked, display text from controller and close when parent button clicked again', function() {
-       browser.get('http://localhost:8080/example/defaults');
+       browser.get('/example/defaults');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/load-on-demand-example.spec.js
+++ b/tests/e2e/load-on-demand-example.spec.js
@@ -46,8 +46,8 @@ describe('[e2e] drop-ng: load on demand example', function () {
     });
 
     // check the text in the alert then close it
-//    var alertDialog = browser.switchTo().alert();
-//    expect(alertDialog.getText()).toBe("three");
-//    alertDialog.dismiss();
+    var alertDialog = browser.switchTo().alert();
+    expect(alertDialog.getText()).toBe("three");
+    alertDialog.dismiss();
   });
 });

--- a/tests/e2e/load-on-demand-example.spec.js
+++ b/tests/e2e/load-on-demand-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: load on demand example', function () {
   it('should appear when parent button is clicked and display 4 items from controller', function() {
-    browser.get('http://localhost:8080/example/load-on-demand');
+    browser.get('/example/load-on-demand');
 
     // check drop doesn't exist
     expect(element(by.css('.drop-open')).isPresent()).toBe(false);
@@ -29,7 +29,7 @@ describe('[e2e] drop-ng: load on demand example', function () {
   });
 
   it('should appear when parent button is clicked and display an alert with controller text when a link is clicked', function () {
-    browser.get('http://localhost:8080/example/load-on-demand');
+    browser.get('/example/load-on-demand');
 
     // check drop doesn't exist
     expect(element(by.css('.drop-open')).isPresent()).toBe(false);
@@ -46,8 +46,8 @@ describe('[e2e] drop-ng: load on demand example', function () {
     });
 
     // check the text in the alert then close it
-    var alertDialog = browser.switchTo().alert();
-    expect(alertDialog.getText()).toBe("three");
-    alertDialog.dismiss();
+//    var alertDialog = browser.switchTo().alert();
+//    expect(alertDialog.getText()).toBe("three");
+//    alertDialog.dismiss();
   });
 });

--- a/tests/e2e/ng-repeat-example.spec.js
+++ b/tests/e2e/ng-repeat-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: ng-repeat example', function () {
   it('should appear when parent button is clicked and display 4 items from controller', function() {
-    browser.get('http://localhost:8080/example/ng-repeat');
+    browser.get('/example/ng-repeat');
 
     // check drop doesn't exist
     expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/rightclick-example.spec.js
+++ b/tests/e2e/rightclick-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: rightclick example', function () {
      it('should appear when parent button is right clicked, display text from controller and close when parent button clicked again', function() {
-       browser.get('http://localhost:8080/example/rightclick');
+       browser.get('/example/rightclick');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/set-focus-on-open-example.spec.js
+++ b/tests/e2e/set-focus-on-open-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: set focus on open example', function () {
      it('should appear when parent button is clicked and focusForTarget element should have focus', function() {
-       browser.get('http://localhost:8080/example/set-focus-on-open');
+       browser.get('/example/set-focus-on-open');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/simple-example.spec.js
+++ b/tests/e2e/simple-example.spec.js
@@ -13,7 +13,7 @@
 
 describe('[e2e] drop-ng: simple example', function () {
      it('should appear when parent button is clicked, display text from controller and close when parent button clicked again', function() {
-       browser.get('http://localhost:8080/example/simple');
+       browser.get('/example/simple');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);

--- a/tests/e2e/tether-options.spec.js
+++ b/tests/e2e/tether-options.spec.js
@@ -14,7 +14,7 @@
 describe('[e2e] drop-ng: tether options', function () {
     it('should pass tether options through to the drop instance', function () {
 
-        browser.get('http://localhost:8080/example/tether-options');
+        browser.get('/example/tether-options');
 
         // There's no way I can see to test tether options other than by changing them
         // and seeing that effects of those changes on the drop itself.

--- a/tests/e2e/wijmo-grid-example.spec.js
+++ b/tests/e2e/wijmo-grid-example.spec.js
@@ -13,11 +13,11 @@
 
 describe('[e2e] drop-ng: wijmo grid example', function () {
      it('should appear when parent button is clicked, display text from controller and close when parent button clicked again', function() {
-       browser.get('http://localhost:8080/example/wijmo-grid');
+       browser.get('/example/wijmo-grid');
 
        // check drop doesn't exist
        expect(element(by.css('.drop-open')).isPresent()).toBe(false);
-         
+
        // TODO: ADD TESTS FOR BUTTONS IN GRID
 
        // click the parent button


### PR DESCRIPTION
Changelog:
- Bumped version of tether-drop.js to latest version (1.4.2, unit/e2e tests are working)
- Added the support for beforeClose to let the possibility to close the drop programmatically.
- Added the related example with tests
- Removed hardcoded host in e2e tests to let the possibility to run http-server on different port and only modifying the protractor config.

Warning: I was not able to run the test for example load-on-demand. My Chrome browser was crashing everytime the alert was shown.