### PR TITLE
Added Scope $apply() so that any rendering done within the openHandle…

### DIFF
--- a/src/drop-ng.js
+++ b/src/drop-ng.js
@@ -119,6 +119,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                     }, ctrl.focusDelay);
                 }
                 scope.callbackOnOpen();
+				scope.$apply();
             }
 
             var closeHandler = function(){


### PR DESCRIPTION
…r would be done before waiting on the focus within the $timeout.

We were noticing that rendering of items populated via the openHandler was not occuring until after the 150ms delay.
When we removed the drop-focus directive we noticed that the render did not occur at all until a digest was triggered.